### PR TITLE
[for-cloud] Update to libtiledb-sql 0.36.0 and libtiledb 2.28

### DIFF
--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -31,7 +31,7 @@ pcre2:
 target_platform:
 - linux-64
 tiledb:
-- '2.27'
+- '2.28'
 xz:
 - '5'
 zlib:

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @dudoslav @ihnorton @jdblischak @shelnutt2
+* @dudoslav @ihnorton @jdblischak @johnkerl @shelnutt2

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,8 @@
 /build_artifacts
 
 *.pyc
+
+# Rattler-build's artifacts are in `output` when not specifying anything.
+/output
+# Pixi's configuration
+.pixi

--- a/.scripts/run_docker_build.sh
+++ b/.scripts/run_docker_build.sh
@@ -12,7 +12,7 @@ source .scripts/logging_utils.sh
 set -xeo pipefail
 
 THISDIR="$( cd "$( dirname "$0" )" >/dev/null && pwd )"
-PROVIDER_DIR="$(basename $THISDIR)"
+PROVIDER_DIR="$(basename "$THISDIR")"
 
 FEEDSTOCK_ROOT="$( cd "$( dirname "$0" )/.." >/dev/null && pwd )"
 RECIPE_ROOT="${FEEDSTOCK_ROOT}/recipe"

--- a/README.md
+++ b/README.md
@@ -139,5 +139,6 @@ Feedstock Maintainers
 * [@dudoslav](https://github.com/dudoslav/)
 * [@ihnorton](https://github.com/ihnorton/)
 * [@jdblischak](https://github.com/jdblischak/)
+* [@johnkerl](https://github.com/johnkerl/)
 * [@shelnutt2](https://github.com/shelnutt2/)
 

--- a/build-locally.py
+++ b/build-locally.py
@@ -10,6 +10,7 @@ import glob
 import os
 import platform
 import subprocess
+import sys
 from argparse import ArgumentParser
 
 
@@ -44,10 +45,19 @@ def run_osx_build(ns):
     subprocess.check_call([script])
 
 
+def run_win_build(ns):
+    script = ".scripts/run_win_build.bat"
+    subprocess.check_call(["cmd", "/D", "/Q", "/C", f"CALL {script}"])
+
+
 def verify_config(ns):
+    choices_filter = ns.filter or "*"
     valid_configs = {
-        os.path.basename(f)[:-5] for f in glob.glob(".ci_support/*.yaml")
+        os.path.basename(f)[:-5]
+        for f in glob.glob(f".ci_support/{choices_filter}.yaml")
     }
+    if choices_filter != "*":
+        print(f"filtering for '{choices_filter}.yaml' configs")
     print(f"valid configs are {valid_configs}")
     if ns.config in valid_configs:
         print("Using " + ns.config + " configuration")
@@ -60,30 +70,37 @@ def verify_config(ns):
         selections = list(enumerate(sorted(valid_configs), 1))
         for i, c in selections:
             print(f"{i}. {c}")
-        s = input("\n> ")
+        try:
+            s = input("\n> ")
+        except KeyboardInterrupt:
+            print("\nno option selected, bye!", file=sys.stderr)
+            sys.exit(1)
         idx = int(s) - 1
         ns.config = selections[idx][1]
         print(f"selected {ns.config}")
     else:
         raise ValueError("config " + ns.config + " is not valid")
-    # Remove the following, as implemented
-    if ns.config.startswith("win"):
-        raise ValueError(
-            f"only Linux/macOS configs currently supported, got {ns.config}"
+    if (
+        ns.config.startswith("osx")
+        and platform.system() == "Darwin"
+        and not os.environ.get("OSX_SDK_DIR")
+    ):
+        raise RuntimeError(
+            "Need OSX_SDK_DIR env variable set. Run 'export OSX_SDK_DIR=$PWD/SDKs' "
+            "to download the SDK automatically to '$PWD/SDKs/MacOSX<ver>.sdk'. "
+            "Note: OSX_SDK_DIR must be set to an absolute path. "
+            "Setting this variable implies agreement to the licensing terms of the SDK by Apple."
         )
-    elif ns.config.startswith("osx"):
-        if "OSX_SDK_DIR" not in os.environ:
-            raise RuntimeError(
-                "Need OSX_SDK_DIR env variable set. Run 'export OSX_SDK_DIR=$PWD/SDKs' "
-                "to download the SDK automatically to '$PWD/SDKs/MacOSX<ver>.sdk'. "
-                "Note: OSX_SDK_DIR must be set to an absolute path. "
-                "Setting this variable implies agreement to the licensing terms of the SDK by Apple."
-            )
 
 
 def main(args=None):
     p = ArgumentParser("build-locally")
     p.add_argument("config", default=None, nargs="?")
+    p.add_argument(
+        "--filter",
+        default=None,
+        help="Glob string to filter which build choices are presented in interactive mode.",
+    )
     p.add_argument(
         "--debug",
         action="store_true",
@@ -104,6 +121,8 @@ def main(args=None):
             run_docker_build(ns)
         elif ns.config.startswith("osx"):
             run_osx_build(ns)
+        elif ns.config.startswith("win"):
+            run_win_build(ns)
     finally:
         recipe_license_file = os.path.join(
             "recipe", "recipe-scripts-license.txt"

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -8,3 +8,5 @@ channel_targets:
   - tiledb for-cloud
 lz4_c:
   - 1.9.3
+pcre2:
+  - 10.44

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "libtiledb-sql" %}
-{% set version = "0.35.0" %}
-{% set sha256 = "6ca6069a1962f8250ab69a3740bd62be4e72bd0633ee5018e70b194cd217d55e" %}
+{% set version = "0.36.0" %}
+{% set sha256 = "e398be0c81be2a2c6d444d8dcaf3cfce701663d74dda9a000cb4ec5941559218" %}
 
 package:
   name: {{ name }}
@@ -19,7 +19,7 @@ build:
 
 requirements:
   build:
-    - cmake
+    - cmake <4
     - make  # [not win]
     - pkg-config  # [not win]
     - wget  # [unix]
@@ -31,7 +31,7 @@ requirements:
     - bison
   host:
     - openssl
-    - tiledb 2.27.*
+    - tiledb 2.28.*
     - libcurl
     - zlib
     - bzip2
@@ -72,6 +72,7 @@ about:
 
 extra:
   recipe-maintainers:
+    - johnkerl
     - jdblischak
     - dudoslav
     - shelnutt2


### PR DESCRIPTION
I followed the instructions in https://github.com/conda-forge/libtiledb-sql-feedstock/issues/191 to create a "for-cloud" variant of libtiledb-sql that can be installed with the legacy requirements of our cloud image.

xref: https://github.com/conda-forge/libtiledb-sql-feedstock/pull/199, https://github.com/conda-forge/libtiledb-sql-feedstock/pull/200, #2 

Notes:

* Included upper bound on CMake (https://github.com/conda-forge/libtiledb-sql-feedstock/pull/197)
* Pinned pcre2 to 10.44. conda-forge has migrated to 10.45 (https://github.com/conda-forge/libtiledb-sql-feedstock/pull/198), but I confirmed our cloud image still uses 10.44
* Continued to _not_ migrate xz (https://github.com/TileDB-Inc/libtiledb-sql-feedstock/commit/e0bea890e462cfb48e2e4454c3c9616628adb0bc)