### PR TITLE
Add back pin for lz4-c 1.9

### DIFF
--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -19,7 +19,7 @@ krb5:
 libcurl:
 - '8'
 lz4_c:
-- '1.10'
+- 1.9.3
 ncurses:
 - '6'
 openssl:
@@ -28,8 +28,6 @@ pcre2:
 - '10.47'
 target_platform:
 - linux-64
-tiledb:
-- '2.30'
 xz:
 - '5'
 zlib:

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -6,3 +6,5 @@ channel_sources:
   - tiledb/label/for-cloud,conda-forge
 channel_targets:
   - tiledb for-cloud
+lz4_c:
+  - 1.9.3

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 3
+  number: 4
   skip: true  # [not linux]
   missing_dso_whitelist:
     - /usr/lib/libncurses.5.4.dylib  # [osx]


### PR DESCRIPTION
To unblock tiledb 2.30 deployment to cloud (#7), restore the pin to lz4-c 1.9 (bumped to 1.10 in #6)

The cloud notebook image is stuck on lz4-c 1.9 due to other outdated dependencies (eg pyarrow 11). The binary produced by #6 (build number 2) was never actually installed in the cloud notebook image since it was incompatible:

```sh
# notebook genomics image

# build num 1 is installed, not 2
conda list | grep libtiledb-sql
## libtiledb-sql             0.37.0               h5c4c1a5_1    tiledb/label/for-cloud
## libtiledb-sql-py          2.1.5            py39ha5cd106_1    conda-forge
conda list | grep lz4
## lz4                       4.3.3            py39hd7df8f7_1    conda-forge
## lz4-c                     1.9.4                hcb278e6_0    conda-forge
```

This PR will create a binary pinned to lz4-c 1.9 and tiledb 2.30